### PR TITLE
Removed non existing servlet mapping.

### DIFF
--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -96,17 +96,6 @@
 
 
     <servlet>
-        <servlet-name>GetPdf2JavaScriptHandlerServlet</servlet-name>
-        <servlet-class>com.groupdocs.viewer.samples.javaweb.servlet.GetPdf2JavaScriptHandlerServlet</servlet-class>
-    </servlet>
-
-    <servlet-mapping>
-        <servlet-name>GetPdf2JavaScriptHandlerServlet</servlet-name>
-        <url-pattern>/document-viewer/GetPdf2JavaScriptHandler</url-pattern>
-    </servlet-mapping>
-
-
-    <servlet>
         <servlet-name>GetPrintableHtmlHandlerServlet</servlet-name>
         <servlet-class>com.groupdocs.viewer.samples.javaweb.servlet.GetPrintableHtmlHandlerServlet</servlet-class>
     </servlet>


### PR DESCRIPTION
GetPdf2JavaScriptHandlerServlet was removed in c00a225 but its servlet mapping left in the web.xml which prevents the sample from running.